### PR TITLE
Zaawansowane filtry nie dla prostych blokerów reklam

### DIFF
--- a/templates/PPB.template
+++ b/templates/PPB.template
@@ -64,4 +64,6 @@
 !
 !
 ! Dołączenie listy uzupełniającej do uBlocka Origin i AdGuarda, by użytkownicy nie musieli jej subskrybować
+!#if (!adguard_ext_android_cb && !adguard_ext_safari && !adguard_app_ios)
 !#include PPB_uBlock_AdGuard.txt
+!#endif

--- a/templates/PPB_uBlock_AdGuard.template
+++ b/templates/PPB_uBlock_AdGuard.template
@@ -16,7 +16,6 @@
 !
 !
 @path PPB/uBO_AG
-!#if (!adguard_ext_android_cb && !adguard_ext_safari && !adguard_app_ios)
 ! Newslettery
 @include newslettery_suplement
 !
@@ -93,7 +92,6 @@
 !#endif
 !#if ext_ublock
 @include specjalne_uBO
-!#endif
 !#endif
 !
 !

--- a/templates/PPB_uBlock_AdGuard.template
+++ b/templates/PPB_uBlock_AdGuard.template
@@ -16,6 +16,9 @@
 !
 !
 @path PPB/uBO_AG
+!#if !adguard_ext_android_cb 
+!#if !adguard_ext_safari 
+!#if !adguard_app_ios
 ! Newslettery
 @include newslettery_suplement
 !
@@ -92,6 +95,9 @@
 !#endif
 !#if ext_ublock
 @include specjalne_uBO
+!#endif
+!#endif
+!#endif
 !#endif
 !
 !

--- a/templates/PPB_uBlock_AdGuard.template
+++ b/templates/PPB_uBlock_AdGuard.template
@@ -16,9 +16,7 @@
 !
 !
 @path PPB/uBO_AG
-!#if !adguard_ext_android_cb 
-!#if !adguard_ext_safari 
-!#if !adguard_app_ios
+!#if (!adguard_ext_android_cb && !adguard_ext_safari && !adguard_app_ios)
 ! Newslettery
 @include newslettery_suplement
 !
@@ -95,9 +93,6 @@
 !#endif
 !#if ext_ublock
 @include specjalne_uBO
-!#endif
-!#endif
-!#endif
 !#endif
 !
 !

--- a/templates/PPB_uBlock_AdGuard.template
+++ b/templates/PPB_uBlock_AdGuard.template
@@ -94,6 +94,7 @@
 !#if ext_ublock
 @include specjalne_uBO
 !#endif
+!#endif
 !
 !
 !@POCZĄTEK DOŁĄCZONYCH POLSKICH FILTRÓW RODO-CIASTECZKOWYCH


### PR DESCRIPTION
! filters for modern uBlock Origin and AdGuard Adblocker / AdGuard APP (macOS, Windows, Android).
! "modern" - support `:style()` filters.

---

fix #1463 